### PR TITLE
Don't pollute global Array prototype

### DIFF
--- a/static/js/stats.js
+++ b/static/js/stats.js
@@ -39,7 +39,7 @@ exports.wordCount = function(){
     var lineCount = 0;
     $(this).contents().each(function(){
        var numberOf = $(this).text().split(" ");
-       numberOf = numberOf.clean(""); // dont include spaces or line breaks or other nastyness
+       numberOf = arrayDelete(numberOf, ""); // dont include spaces or line breaks or other nastyness
        lineCount += numberOf.length;
     });
     totalCount += lineCount;
@@ -294,13 +294,12 @@ function authorColorFromClass(authorClass){ // turn authorClass into authorID th
 }
 
 
-Array.prototype.clean = function(deleteValue) {
+function arrayDelete(array, deleteValue) {
   for (var i = 0; i < this.length; i++) {
-    if (this[i] == deleteValue) {         
+    if (this[i] == deleteValue) {
       this.splice(i, 1);
       i--;
     }
   }
   return this;
-};
-
+}


### PR DESCRIPTION
It causes crashes in unrelated parts of code.

In particular:
```
jan. 11 17:00:59 skog node[21461]: [2017-01-11 17:00:59.264] [ERROR] console - TypeError: Cannot set property 'writingInProgress' of undefined
jan. 11 17:00:59 skog node[21461]:     at /srv/www/pad.s0.no/etherpad-lite/src/node_modules/ueberdb2/CacheAndBufferLayer.js:489:56
jan. 11 17:00:59 skog node[21461]:     at /srv/www/pad.s0.no/etherpad-lite/src/node_modules/ueberdb2/node_modules/async/lib/async.js:199:13
jan. 11 17:00:59 skog node[21461]:     at /srv/www/pad.s0.no/etherpad-lite/src/node_modules/ueberdb2/node_modules/async/lib/async.js:105:25
jan. 11 17:00:59 skog node[21461]:     at /srv/www/pad.s0.no/etherpad-lite/src/node_modules/ueberdb2/node_modules/async/lib/async.js:196:17
jan. 11 17:00:59 skog node[21461]:     at Query._callback (/srv/www/pad.s0.no/etherpad-lite/src/node_modules/ueberdb2/node_modules/async/lib/async.js:467:34)
jan. 11 17:00:59 skog node[21461]:     at Query.Sequence.end (/srv/www/pad.s0.no/etherpad-lite/src/node_modules/mysql/lib/protocol/sequences/Sequence.js:96:24)
jan. 11 17:00:59 skog node[21461]:     at Query._handleFinalResultPacket (/srv/www/pad.s0.no/etherpad-lite/src/node_modules/mysql/lib/protocol/sequences/Query.js:144:8)
jan. 11 17:00:59 skog node[21461]:     at Query.OkPacket (/srv/www/pad.s0.no/etherpad-lite/src/node_modules/mysql/lib/protocol/sequences/Query.js:78:10)
jan. 11 17:00:59 skog node[21461]:     at Protocol._parsePacket (/srv/www/pad.s0.no/etherpad-lite/src/node_modules/mysql/lib/protocol/Protocol.js:271:23)   
jan. 11 17:00:59 skog node[21461]:     at Parser.write (/srv/www/pad.s0.no/etherpad-lite/src/node_modules/mysql/lib/protocol/Parser.js:77:12)
jan. 11 17:00:59 skog node[21461]: [2017-01-11 17:00:59.264] [INFO] console - graceful shutdown...
```
